### PR TITLE
Add links from calendar list to subscription detail

### DIFF
--- a/app/(dashboard)/calendar/page.tsx
+++ b/app/(dashboard)/calendar/page.tsx
@@ -8,6 +8,7 @@ import { calculateNextRenewal, formatCurrency, formatDate } from "@/lib/utils";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { RenewalCalendar } from "@/components/ui/renewal-calendar";
+import Link from "next/link";
 
 export default async function CalendarPage() {
   const session = await auth.api.getSession({
@@ -109,20 +110,24 @@ export default async function CalendarPage() {
                     </div>
                     <div className="space-y-2">
                       {renewals.map((renewal) => (
-                        <div key={renewal.id} className="flex items-center justify-between p-2 bg-muted/50 rounded">
+                        <Link
+                          key={renewal.id}
+                          href={`/subscriptions/${renewal.id}`}
+                          className="flex items-center justify-between p-2 bg-muted/50 rounded hover:bg-muted transition-colors"
+                        >
                           <div className="flex items-center gap-2">
                             <div className="h-8 w-8 bg-primary/10 rounded flex items-center justify-center">
                               <span className="text-sm font-bold">{renewal.serviceName.charAt(0)}</span>
                             </div>
                             <div>
-                              <p className="font-medium">{renewal.serviceName}</p>
+                              <p className="font-medium hover:underline">{renewal.serviceName}</p>
                               <p className="text-xs text-muted-foreground">{renewal.billingCycle}</p>
                             </div>
                           </div>
                           <div className="text-right">
                             <p className="font-medium">{formatCurrency(renewal.price, renewal.currency)}</p>
                           </div>
-                        </div>
+                        </Link>
                       ))}
                     </div>
                   </div>


### PR DESCRIPTION
## Summary
- link each upcoming renewal on the calendar page to the subscription view page

## Testing
- `npm run lint` *(fails: react/no-unescaped-entities, unused vars, etc.)*
- `npm test` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6847d82e8814832fbbac78a3f431a421

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Upcoming renewals in the calendar are now clickable, allowing direct navigation to the subscription detail page.

- **Style**
  - Added hover effects to renewal items, including background color transitions and underlined service names for improved interactivity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->